### PR TITLE
Fix "invalid use of incomplete type ‘std::stringstream'" (#36)

### DIFF
--- a/include/export/jwtpp/jwtpp.hh
+++ b/include/export/jwtpp/jwtpp.hh
@@ -26,6 +26,7 @@
 #include <functional>
 #include <vector>
 #include <string>
+#include <sstream>
 
 #include <json/json.h>
 


### PR DESCRIPTION
* Fix "invalid use of incomplete type ‘std::stringstream'"

Include <sstream> to fix this issue for gcc7/8 on linux

Same fix as 37ac531413b0b571aca052fce2eb237a056dc4bb but
for new files, I guess

* FIx Moved includes to jwtpp.hh

Co-authored-by: Anton Schmidt <shas@tsfer.ru>